### PR TITLE
Split loading of the whole stake account data

### DIFF
--- a/src/components/StakeAccount.tsx
+++ b/src/components/StakeAccount.tsx
@@ -50,7 +50,7 @@ export function StakeAccountCard({stakeAccountMeta}: {stakeAccountMeta: StakeAcc
 
   const totalRewards = useMemo(() => {
     return stakeAccountMeta.inflationRewards.reduce((sum, current) => sum + current.amount, 0)
-  }, [stakeAccountMeta]);
+  }, [stakeAccountMeta.inflationRewards]);
 
   useEffect(() => {
     setActivatedBlockTime(undefined);

--- a/src/utils/stakeAccounts.ts
+++ b/src/utils/stakeAccounts.ts
@@ -37,7 +37,7 @@ export function sortStakeAccountMetas(stakeAccountMetas: StakeAccountMeta[]) {
   });
 }
 
-export async function findStakeAccountMetas(connection: Connection, walletAddress: PublicKey): Promise<StakeAccountMeta[]> {
+export async function findStakeAccountMetas(connection: Connection, walletAddress: PublicKey, setStakeAccounts: (sam: StakeAccountMeta[]) => void): Promise<StakeAccountMeta[]> {
   let newStakeAccountMetas: StakeAccountMeta[] = [];
 
   // Create potential solflare seed PDAs
@@ -93,6 +93,9 @@ export async function findStakeAccountMetas(connection: Connection, walletAddres
     .filter(meta => meta.stakeAccount.info.stake?.delegation.activationEpoch)
     .map(meta => meta.stakeAccount.info.stake?.delegation.activationEpoch?.toNumber() ?? 1000) // null coallescing not possible here
 
+  sortStakeAccountMetas(newStakeAccountMetas);
+  setStakeAccounts(newStakeAccountMetas);
+
   if(delegatedActivationEpochs.length !== 0) {
     const minEpoch = Math.min(
       ...delegatedActivationEpochs
@@ -109,8 +112,6 @@ export async function findStakeAccountMetas(connection: Connection, walletAddres
         'finalized'
       ));
     }
-
-    sortStakeAccountMetas(newStakeAccountMetas);
 
     const inflationRewardsResults = await promiseAllInBatches(tasks, 4);
     inflationRewardsResults.forEach(inflationRewards => inflationRewards.forEach((inflationReward, index) => {

--- a/src/views/DApp.tsx
+++ b/src/views/DApp.tsx
@@ -125,7 +125,7 @@ function DApp() {
     const newPublicKey = connected ? wallet?.publicKey : manualPublicKey;
     if (newPublicKey) {
       setLoading(true);
-      findStakeAccountMetas(connection, newPublicKey)
+      findStakeAccountMetas(connection, newPublicKey, setStakeAccounts)
         .then(newStakeAccounts => {
           setStakeAccounts(newStakeAccounts);
           setLoading(false);


### PR DESCRIPTION
![Screenshot from 2021-08-19 19-33-25](https://user-images.githubusercontent.com/8245419/130045687-9d2d7e37-14cf-4e4c-8859-29261920a444.png)

@neohexane We need to tune that a little bit, no need for a spinning animation, but we need to indicate that the rewards are loading